### PR TITLE
update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 build = "build.rs"
 
 [build-dependencies]
-case = "0.0"
+case = "0.1"
 serde_codegen = "0.8"
 serde_json = "0.8"
 glob = "0.2.11"
@@ -23,7 +23,7 @@ env_logger = "0.3"
 [dependencies]
 hex = "0.2.0"
 case = "0.0"
-hyper = "0.9"
+hyper = "0.10"
 rust-crypto = "0.2"
 log = "0.3"
 env_logger = "0.3"


### PR DESCRIPTION
I want to use this great crate with hyper 0.10. I just applied [cargo outdated](https://github.com/kbknapp/cargo-outdated).