### PR TITLE
Upgrade hyper to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ env_logger = "0.3"
 [dependencies]
 hex = "0.2.0"
 case = "0.0"
-hyper = "0.9"
+hyper = "0.10"
 rust-crypto = "0.2"
 log = "0.3"
 env_logger = "0.3"


### PR DESCRIPTION
This avoids versioning conflicts when combined with other crates (e.g., git2 and slack-hook); seems like none of the breaking changes in 0.10 affect afterparty.